### PR TITLE
feat: impl interface and denominations

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -23,9 +23,11 @@ This specification provides a standard API aimed to serve the majority of use ca
 ### Methods
 
 #### valueOf
-Returns the value of `baseAmount` of `baseAsset` in `quoteAsset` terms.
+Returns the value of `baseAmount` of `base` in `quote` terms.
 
-MUST revert with `OracleUnsupportedPair` if not capable to provide data for the specified `baseAsset` and `quoteAsset` pair.
+MUST round down towards 0.
+
+MUST revert with `OracleUnsupportedPair` if not capable to provide data for the specified `base` and `quote` pair.
 
 MUST revert with `OracleUntrustedData` if not capable to provide data within a degree of confidence publicly specified.
 
@@ -48,9 +50,11 @@ MUST revert with `OracleUntrustedData` if not capable to provide data within a d
 ```
 
 #### priceOf
-Returns the value of one `whole unit` of `baseAsset` in `quoteAsset` terms, as a fixed point value with 18 decimals.
+Returns the value of one `whole unit` of `base` in `quote` terms, as a fixed point value with 18 decimals.
 
-MUST revert with `OracleUnsupportedPair` if not capable to provide data for the specified `baseAsset` and `quoteAsset` pair.
+MUST round down towards 0.
+
+MUST revert with `OracleUnsupportedPair` if not capable to provide data for the specified `base` and `quote` pair.
 
 MUST revert with `OracleUntrustedData` if not capable to provide data within a degree of confidence publicly specified.
 
@@ -73,11 +77,11 @@ MUST revert with `OracleUntrustedData` if not capable to provide data within a d
 ### Special Addresses
 Some assets under the scope of this specification don't have an address, such as ETH, BTC and national currencies.
 
-For ETH, ERC-7535 will be applied, using  0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE as its address.
+For ETH, ERC-7535 will be applied, using `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` as its address.
 
-For BTC, the address will be 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB.
+For BTC, the address will be `0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB`.
 
-For assets without an address, but with an ISO 4217 code, the code will be used (e.g. address(840) for USD).
+For assets without an address, but with an ISO 4217 code, the code will be used (e.g. `address(840)` for USD).
 
 ### Events
 There are no events defined in this specification
@@ -87,28 +91,24 @@ There are no events defined in this specification
 #### OracleUnsupportedPair
 ```yaml
 - name: OracleUnsupportedPair
-  type: event
+  type: error
 
   inputs:
     - name: base
-      indexed: true
       type: address
     - name: quote
-      indexed: true
       type: address
 ```
 
 #### OracleUntrustedData
 ```yaml
-- name: OracleUnsupportedPair
-  type: event
+- name: OracleUntrustedData
+  type: error
 
   inputs:
     - name: base
-      indexed: true
       type: address
     - name: quote
-      indexed: true
       type: address
 ```
 

--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Common interface for price oracles.
+/// @dev Implements the spec at https://github.com/alcueca/oracles/blob/main/spec/spec.md.
+interface IOracle {
+    /// @notice The oracle does not support the given base/quote pair.
+    /// @param base The asset that the user needs to know the value or price for.
+    /// @param quote The asset in which the user needs to value or price the base.
+    error OracleUnsupportedPair(address base, address quote);
+
+    /// @notice The oracle is not capable to provide data within a degree of confidence.
+    /// @param base The asset that the user needs to know the value or price for.
+    /// @param quote The asset in which the user needs to value or price the base.
+    error OracleUntrustedData(address base, address quote);
+
+    /// @notice Returns the value of `baseAmount` of `base` in `quote` terms.
+    /// @dev MUST round down towards 0.
+    /// MUST revert with `OracleUnsupportedPair` if not capable to provide data for the specified `base` and `quote` pair.
+    /// MUST revert with `OracleUntrustedData` if not capable to provide data within a degree of confidence publicly specified.
+    /// @param base The asset that the user needs to know the value for.
+    /// @param quote The asset in which the user needs to value the base.
+    /// @param baseAmount The amount of `base` to convert.
+    /// @return quoteAmount The value of `baseAmount` of `base` in `quote` terms
+    function valueOf(address base, address quote, uint256 baseAmount) external view returns (uint256 quoteAmount);
+
+    /// @notice Returns the value of one `whole unit` of `base` in `quote` terms, as a fixed point value with 18 decimals.
+    /// @dev MUST round down towards 0.
+    /// MUST revert with `OracleUnsupportedPair` if not capable to provide data for the specified `base` and `quote` pair.
+    /// MUST revert with `OracleUntrustedData` if not capable to provide data within a degree of confidence publicly specified.
+    /// @param base The asset that the user needs to know the price for.
+    /// @param quote The asset in which the user needs to price the base.
+    /// @return baseQuotePrice The value of one whole unit of `base` in `quote` terms, as a fixed point value with 18 decimals.
+    function priceOf(address base, address quote) external view returns (uint256 baseQuotePrice);
+}

--- a/src/lib/Denominations.sol
+++ b/src/lib/Denominations.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Conventional representation of non-ERC20 assets.
+/// @dev For ETH, ERC-7535 will be applied, using `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` as its address.
+/// @dev For BTC, the address will be `0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB`.
+/// @dev For national currencies and precious metals, the respective ISO 4217 code will be used.
+library Denominations {
+    address public constant ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address public constant BTC = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
+    address public constant USD = address(840);
+}


### PR DESCRIPTION
I implemented the specification in `interfaces/IOracle.sol` and the convention for special addresses in `lib/Denominations.sol`.

Changes to `spec.md`:
- Explicitly prescribe that `valueOf` and `priceOf` MUST round down towards 0.
- Changed type on the errors specification yaml to `error`. Removed `indexed` because errors do not support indexed params.
- Various formatting and naming fixes for consistency.

After this is merged we should have all oracles implement this interface.

We can create a common abstract base class that implements `valueOf` and `priceOf` by calling a virtual function overridden in the implementation. This way oracles (e.g. LidoOracle and ERC4626Oracle) need not duplicate the if-else logic.
