### PR TITLE
ComposerOracle draft

### DIFF
--- a/src/composer/ComposerOracle.sol
+++ b/src/composer/ComposerOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
 import {IOracle} from "../interfaces/IOracle.sol";

--- a/src/composer/ComposerOracle.sol
+++ b/src/composer/ComposerOracle.sol
@@ -5,6 +5,8 @@ import {IOracle} from "../interfaces/IOracle.sol";
 import {BoringERC20} from "../libraries/BoringERC20.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
+import { console2 } from "forge-std/console2.sol";
+
 /**
  * @title ComposerOracle
  */
@@ -73,13 +75,17 @@ contract ComposerOracle is IOracle {
         address[] memory path
     ) internal {
         uint256 pathLength = path.length;
+        
+        // Check that oracles for all intermediate pairs exist
         unchecked {
+            address base_ = base;
             for (uint256 p; p < pathLength; ++p) {
-                OracleWithDecimals memory oracle_ = oracles[base][path[p]];
-                if(oracle_.oracle == IOracle(address(0))) revert OracleUnsupportedPair(base, path[p]);
-                base = path[p];
+                OracleWithDecimals memory oracle_ = oracles[base_][path[p]];
+                if(oracle_.oracle == IOracle(address(0))) revert OracleUnsupportedPair(base_, path[p]);
+                base_ = path[p];
             }
         }
+
         paths[base][quote] = path;
         emit PathSet(base, quote, path);
     }

--- a/src/composer/ComposerOracle.sol
+++ b/src/composer/ComposerOracle.sol
@@ -32,8 +32,8 @@ contract ComposerOracle is IOracle {
         address[] path;
     }
 
-    mapping(address => mapping(address => OracleWithDecimals)) public oracles;
-    mapping(address => mapping(address => address[])) public paths;
+    mapping(address base => mapping(address quote => OracleWithDecimals oracle)) public oracles;
+    mapping(address base => mapping(address quote => address[] path)) public paths;
 
     constructor (SetOracle[] memory oracles_, SetPath[] memory paths_) {
         uint256 oraclesLength = oracles_.length;

--- a/src/composer/ComposerOracle.sol
+++ b/src/composer/ComposerOracle.sol
@@ -111,8 +111,12 @@ contract ComposerOracle is IOracle {
         address base,
         address quote
     ) external view virtual override returns (uint256 price) {
-        address[] memory path = paths[base][quote];
-        OracleWithDecimals memory oracle = oracles[base][path[0]];
+        OracleWithDecimals memory oracle = oracles[base][quote];
+        if (address(oracle.oracle) == address(0)) { // No direct oracle, check path
+            address[] memory path = paths[base][quote];
+            if (path.length == 0) revert OracleUnsupportedPair(base, quote);
+            oracle = oracles[base][path[0]];
+        }
         uint256 baseUnit = 10 ** oracle.baseDecimals;
 
         price = _valueOfPath(base, quote, baseUnit) * 1e18 / 10 ** oracle.quoteDecimals;

--- a/src/composer/ComposerOracle.sol
+++ b/src/composer/ComposerOracle.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.0;
+
+import {IOracle} from "../interfaces/IOracle.sol";
+import {BoringERC20} from "../libraries/BoringERC20.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+/**
+ * @title ComposerOracle
+ */
+contract ComposerOracle is IOracle {
+
+    event OracleSet(address indexed base, address indexed quote, IOracle indexed oracle);
+    event PathSet(address indexed base, address indexed quote, address[] indexed path);
+
+    struct OracleWithDecimals {
+        IOracle oracle;
+        uint8 baseDecimals;
+        uint8 quoteDecimals;
+    }
+
+    struct SetOracle {
+        address base;
+        address quote;
+        OracleWithDecimals oracle;
+    }
+
+    struct SetPath {
+        address base;
+        address quote;
+        address[] path;
+    }
+
+    mapping(address => mapping(address => OracleWithDecimals)) public oracles;
+    mapping(address => mapping(address => address[])) public paths;
+
+    constructor (SetOracle[] memory oracles_, SetPath[] memory paths_) {
+        uint256 oraclesLength = oracles_.length;
+        unchecked {
+            for (uint256 p; p < oraclesLength; ++p) {
+                _setOracle(oracles_[p].base, oracles_[p].quote, oracles_[p].oracle);
+            }
+        }
+        
+        uint256 pathsLength = paths_.length;
+        unchecked {
+            for (uint256 p; p < pathsLength; ++p) {
+                _setPath(paths_[p].base, paths_[p].quote, paths_[p].path);
+            }
+        }
+    }
+
+    /// @notice Set or reset an oracle
+    /// @param base base token
+    /// @param quote quote token
+    /// @param oracle IOracle contract
+    function _setOracle(
+        address base,
+        address quote,
+        OracleWithDecimals memory oracle
+    ) internal {
+        oracles[base][quote] = oracle;
+        emit OracleSet(base, quote, oracle.oracle);
+    }
+
+    /// @notice Set or reset an oracle path
+    /// @param base base token
+    /// @param quote quote token
+    /// @param path Path from base to quote
+    function _setPath(
+        address base,
+        address quote,
+        address[] memory path
+    ) internal {
+        uint256 pathLength = path.length;
+        unchecked {
+            for (uint256 p; p < pathLength; ++p) {
+                OracleWithDecimals memory oracle_ = oracles[base][path[p]];
+                if(oracle_.oracle == IOracle(address(0))) revert OracleUnsupportedPair(base, path[p]);
+                base = path[p];
+            }
+        }
+        paths[base][quote] = path;
+        emit PathSet(base, quote, path);
+    }
+
+    /// @notice Convert amountBase base into quote at the latest oracle price, through a path is exists.
+    /// @param base base token
+    /// @param quote quote token
+    /// @param amountBase Amount of base to convert to quote
+    /// @return amountQuote Amount of quote token converted from base
+    function valueOf(
+        address base,
+        address quote,
+        uint256 amountBase
+    ) external view virtual override returns (uint256 amountQuote) {
+        amountQuote = amountBase;
+        address[] memory path = paths[base][quote];
+        uint256 pathLength = path.length;
+        unchecked {
+            for (uint256 p; p < pathLength; ++p) {
+                amountQuote = _valueOf(base, path[p], amountQuote);
+                base = path[p];
+            }
+        }
+        amountQuote = _valueOf(base, quote, amountQuote);
+    }
+
+    /// @notice Return the price of base in quote terms, with 18 decimals, at the latest oracle price, through a path is exists.
+    /// @param base base token
+    /// @param quote quote token
+    /// @return price price of base in quote terms, with 18 decimals
+    function priceOf(
+        address base,
+        address quote
+    ) external view virtual override returns (uint256 price) {
+        address[] memory path = paths[base][quote];
+        uint256 pathLength = path.length;
+        
+        OracleWithDecimals memory oracle = oracles[base][path[0]];
+        price = 10 ** oracle.baseDecimals;
+        unchecked {
+            for (uint256 p; p < pathLength; ++p) {
+                price = _valueOf(base, path[p], price);
+                base = path[p];
+            }
+        }
+        price = _valueOf(base, quote, price) * 1e18 / 10 ** oracle.quoteDecimals;
+    }
+
+    /// @notice Convert amountBase base into quote at the latest oracle price, through a path is exists.
+    /// @param base base token
+    /// @param quote quote token
+    /// @param amountBase Amount of base to convert to quote
+    /// @return amountQuote Amount of quote token converted from base
+    function _valueOf(
+        address base,
+        address quote,
+        uint256 amountBase
+    ) private view returns (uint256 amountQuote) {
+        OracleWithDecimals memory oracle = oracles[base][quote];
+        if (address(oracle.oracle) == address(0)) revert OracleUnsupportedPair(base, quote);
+        amountQuote = oracle.oracle.valueOf(base, quote, amountBase);
+    }
+}

--- a/src/composer/ComposerOracle.sol
+++ b/src/composer/ComposerOracle.sol
@@ -5,7 +5,6 @@ import {IOracle} from "../interfaces/IOracle.sol";
 import {BoringERC20} from "../libraries/BoringERC20.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
-import { console2 } from "forge-std/console2.sol";
 
 /**
  * @title ComposerOracle

--- a/test/ComposerOracle.t.sol
+++ b/test/ComposerOracle.t.sol
@@ -170,4 +170,22 @@ contract ComposerOracleTest is Test {
         assertEq(composerOracle.valueOf(DAI, DAI, 1e18), 999999_837147_677368);
         // Value obtained experimentally, and explained by the loss of precision in the intermediate steps
     }
+
+    function testDirectPriceOf() public view {
+        // price of DAI in terms of WETH
+        assertEq(composerOracle.priceOf(DAI, WETH), DAI_WETH);
+        // price of WETH in terms of DAI
+        assertEq(composerOracle.priceOf(WETH, DAI), WETH_DAI);
+        // price of USDC in terms of WETH
+        assertEq(composerOracle.priceOf(USDC, WETH), USDC_WETH);
+        // price of WETH in terms of USDC
+        assertEq(composerOracle.priceOf(WETH, USDC), WETH_USDC * 1e12);
+    }
+
+    function testPathPriceOf() public view {
+        // price of DAI in terms of USDC
+        assertEq(composerOracle.priceOf(DAI, USDC), DAI_WETH * WETH_USDC / 1e18);
+        // price of USDC in terms of DAI
+        assertEq(composerOracle.priceOf(USDC, DAI), USDC_WETH * WETH_DAI / 1e18);
+    }
 }

--- a/test/ComposerOracle.t.sol
+++ b/test/ComposerOracle.t.sol
@@ -50,7 +50,7 @@ contract ComposerOracleTest is Test {
         setOracles.push(ComposerOracle.SetOracle({
             base: DAI,
             quote: WETH,
-            oracle: ComposerOracle.OracleWithDecimals({
+            oracleWithDecimals: ComposerOracle.OracleWithDecimals({
                 oracle: chainlinkOracle,
                 baseDecimals: 18,
                 quoteDecimals: 18
@@ -59,7 +59,7 @@ contract ComposerOracleTest is Test {
         setOracles.push(ComposerOracle.SetOracle({
             base: WETH,
             quote: DAI,
-            oracle: ComposerOracle.OracleWithDecimals({
+            oracleWithDecimals: ComposerOracle.OracleWithDecimals({
                 oracle: chainlinkOracle,
                 baseDecimals: 18,
                 quoteDecimals: 18
@@ -68,7 +68,7 @@ contract ComposerOracleTest is Test {
         setOracles.push(ComposerOracle.SetOracle({
             base: USDC,
             quote: WETH,
-            oracle: ComposerOracle.OracleWithDecimals({
+            oracleWithDecimals: ComposerOracle.OracleWithDecimals({
                 oracle: chainlinkOracle,
                 baseDecimals: 6,
                 quoteDecimals: 18
@@ -77,7 +77,7 @@ contract ComposerOracleTest is Test {
         setOracles.push(ComposerOracle.SetOracle({
             base: WETH,
             quote: USDC,
-            oracle: ComposerOracle.OracleWithDecimals({
+            oracleWithDecimals: ComposerOracle.OracleWithDecimals({
                 oracle: chainlinkOracle,
                 baseDecimals: 18,
                 quoteDecimals: 6

--- a/test/ComposerOracle.t.sol
+++ b/test/ComposerOracle.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// types
+import {IOracle} from "../src/interfaces/IOracle.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+// libraries
+import {console2} from "forge-std/Test.sol";
+// contracts
+import {Test} from "forge-std/Test.sol";
+import {ComposerOracle} from "../src/composer/ComposerOracle.sol";
+import {MockOracle} from "./MockOracle.sol";
+
+contract ComposerOracleTest is Test {
+    // composer oracle
+    ComposerOracle composerOracle;
+
+    // mock chainlink oracle
+    MockOracle chainlinkOracle;
+
+    // token constants
+    address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+    // raw chainlink prices at block 19537700
+    uint256 constant DAI_WETH = 284796189987735;
+    uint256 constant WETH_DAI = 3511282928479716769792;
+    uint256 constant USDC_WETH = 284240453521380;
+    uint256 constant WETH_USDC = 3518148059;
+
+    ComposerOracle.SetOracle[] setOracles;
+    ComposerOracle.SetPath[] setPaths;
+    address[] wethPath;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", block.number);
+        chainlinkOracle = new MockOracle();
+        chainlinkOracle.setPair(DAI, 18, WETH, 18, DAI_WETH);
+        chainlinkOracle.setPair(WETH, 18, DAI, 18, WETH_DAI);
+        chainlinkOracle.setPair(USDC, 6, WETH, 18, USDC_WETH);
+        chainlinkOracle.setPair(WETH, 18, USDC, 6, WETH_USDC);
+        wethPath.push(WETH);
+        setOracles.push(ComposerOracle.SetOracle({
+            base: DAI,
+            quote: WETH,
+            oracle: ComposerOracle.OracleWithDecimals({
+                oracle: chainlinkOracle,
+                baseDecimals: 18,
+                quoteDecimals: 18
+            })
+        }));
+        setOracles.push(ComposerOracle.SetOracle({
+            base: WETH,
+            quote: DAI,
+            oracle: ComposerOracle.OracleWithDecimals({
+                oracle: chainlinkOracle,
+                baseDecimals: 18,
+                quoteDecimals: 18
+            })
+        }));
+        setOracles.push(ComposerOracle.SetOracle({
+            base: USDC,
+            quote: WETH,
+            oracle: ComposerOracle.OracleWithDecimals({
+                oracle: chainlinkOracle,
+                baseDecimals: 6,
+                quoteDecimals: 18
+            })
+        }));
+        setOracles.push(ComposerOracle.SetOracle({
+            base: WETH,
+            quote: USDC,
+            oracle: ComposerOracle.OracleWithDecimals({
+                oracle: chainlinkOracle,
+                baseDecimals: 18,
+                quoteDecimals: 6
+            })
+        }));
+
+        setPaths.push(ComposerOracle.SetPath({
+            base: DAI,
+            quote: USDC,
+            path: wethPath
+        }));
+        setPaths.push(ComposerOracle.SetPath({
+            base: USDC,
+            quote: DAI,
+            path: wethPath
+        }));
+
+        composerOracle = new ComposerOracle(setOracles, setPaths);
+    }
+
+//    function testOracleConfig() public view {
+//        assertEq(address(lidoOracle.STETH()), STETH); // stETH config
+//        assertEq(address(lidoOracle.WSTETH()), WSTETH); // wstETH config
+//    }
+//
+//    function testScalarConfig() public view {
+//        // should equal 10 ** asset decimals
+//        assertEq(lidoOracle.WSTETH_SCALAR(), 10 ** IERC20(WSTETH).decimals());
+//        assertEq(lidoOracle.STETH_SCALAR(), 10 ** IERC20(STETH).decimals());
+//    }
+//
+//    function testPriceOf() public view {
+//        // price of one stETH whole unit, in terms of wstETH
+//        assertEq(lidoOracle.priceOf(STETH, WSTETH), STETH_WSTETH);
+//
+//        // price of one wstETH whole unit, in terms of stETH
+//        assertEq(lidoOracle.priceOf(WSTETH, STETH), WSTETH_STETH);
+//    }
+//
+//    function testValueOfStETH(uint256 stETHAmount) public view {
+//        // value of given stETH amount, in terms of wstETH
+//        vm.assume(stETHAmount <= IERC20(STETH).totalSupply());
+//
+//        assertEq(lidoOracle.valueOf(STETH, WSTETH, stETHAmount), IWSTETH(WSTETH).getWstETHByStETH(stETHAmount));
+//    }
+//
+//    function testValueOfWstETH(uint256 wstETHAmount) public view {
+//        // value of given wstETH amount, in terms of stETH
+//        vm.assume(wstETHAmount <= IERC20(WSTETH).totalSupply());
+//
+//        assertEq(lidoOracle.valueOf(WSTETH, STETH, wstETHAmount), IWSTETH(WSTETH).getStETHByWstETH(wstETHAmount));
+//    }
+//
+//    function testInvalidArgs(address base, address quote, uint256 amt) public {
+//        // invalid input args revert with OracleUnsupported()
+//        vm.assume(base != STETH || quote != WSTETH);
+//        vm.assume(base != WSTETH || quote != STETH);
+//
+//        vm.expectRevert(abi.encodeWithSelector(IOracle.OracleUnsupportedPair.selector, base, quote));
+//        lidoOracle.priceOf(base, quote);
+//
+//        vm.expectRevert(abi.encodeWithSelector(IOracle.OracleUnsupportedPair.selector, base, quote));
+//        lidoOracle.valueOf(base, quote, amt);
+//    }
+}

--- a/test/MockOracle.sol
+++ b/test/MockOracle.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// types
+import {IOracle} from "../src/interfaces/IOracle.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {IERC4626} from "forge-std/interfaces/IERC4626.sol";
+// libraries
+import {BoringERC20} from "../src/libraries/BoringERC20.sol";
+
+contract MockOracle is IOracle {
+    struct Pair {
+        uint256 ratio; // With 18 additional decimals
+        uint8 baseDecimals;
+        uint8 quoteDecimals;
+    }
+
+    mapping (address => mapping (address => Pair)) public pairs;
+
+    function setPair(address base, uint8 baseDecimals, address quote, uint8 quoteDecimals, uint256 ratio) public {
+        pairs[base][quote] = Pair({ ratio: ratio, baseDecimals: baseDecimals, quoteDecimals: quoteDecimals });
+    }
+
+    /// @notice Returns the value of baseAmount of baseAsset in quoteAsset terms.
+    /// @param base The asset that the user needs to know the value for.
+    /// @param quote The asset in which the user needs to value the `base`.
+    /// @param baseAmount The amount of `base` that the user wants to know the value in `quote` for.
+    /// @return quoteAmount The amount of `quote` that has the same value as `baseAmount`.
+    function valueOf(address base, address quote, uint256 baseAmount) external view returns (uint256 quoteAmount) {
+        Pair memory pair = pairs[base][quote];
+        if (pair.ratio == 0) revert OracleUnsupportedPair(base, quote);
+        return baseAmount * pair.ratio;
+    }
+
+    /// @notice Returns the price of baseAsset in quoteAsset terms.
+    /// @param base The asset that the user needs to know the price for.
+    /// @param quote The asset in which the user needs to price the `base`.
+    /// @return baseQuotePrice The value of a minimum representable unit of `base` in `quote` terms, as an FP18.
+    function priceOf(address base, address quote) external view returns (uint256 baseQuotePrice) {
+        Pair memory pair = pairs[base][quote];
+        if (pair.ratio == 0) revert OracleUnsupportedPair(base, quote);
+        return 10 ** pair.baseDecimals * pair.ratio * 1e18 / 10 ** pair.quoteDecimals;
+    }
+}

--- a/test/MockOracle.sol
+++ b/test/MockOracle.sol
@@ -10,7 +10,7 @@ import {BoringERC20} from "../src/libraries/BoringERC20.sol";
 
 contract MockOracle is IOracle {
     struct Pair {
-        uint256 ratio; // With 18 additional decimals
+        uint256 ratio; // One unit of base, in quote terms
         uint8 baseDecimals;
         uint8 quoteDecimals;
     }
@@ -29,7 +29,7 @@ contract MockOracle is IOracle {
     function valueOf(address base, address quote, uint256 baseAmount) external view returns (uint256 quoteAmount) {
         Pair memory pair = pairs[base][quote];
         if (pair.ratio == 0) revert OracleUnsupportedPair(base, quote);
-        return baseAmount * pair.ratio;
+        return baseAmount * pair.ratio / 10 ** pair.baseDecimals;
     }
 
     /// @notice Returns the price of baseAsset in quoteAsset terms.
@@ -39,6 +39,6 @@ contract MockOracle is IOracle {
     function priceOf(address base, address quote) external view returns (uint256 baseQuotePrice) {
         Pair memory pair = pairs[base][quote];
         if (pair.ratio == 0) revert OracleUnsupportedPair(base, quote);
-        return 10 ** pair.baseDecimals * pair.ratio * 1e18 / 10 ** pair.quoteDecimals;
+        return pair.ratio * 1e18 / 10 ** pair.quoteDecimals;
     }
 }


### PR DESCRIPTION
This ComposerOracle is adapted from the one at [Yield](https://github.com/yieldprotocol/vault-v2/blob/master/src/oracles/composite/CompositeMultiOracle.sol), aiming to the simplest possible permissionless implementation.

Setup is only done during construction. Empty paths are allowed. Reverses are not automatically configured.

As usual, deployment should be done carefully and all features tested before release, as minimal checks are done by the contract itself during setup. I'm not adding address(0) checks.

I'm sure that the code style and UX can be done better, please don't hesitate to tell me my code is ugly.